### PR TITLE
fix: experience optimization

### DIFF
--- a/packages/common/Display.vue
+++ b/packages/common/Display.vue
@@ -120,7 +120,7 @@
 
         emit("update:color", state.color);
         emit("change", state.color);
-      }, 300);
+      }, 800);
 
       whenever(
         () => props.color,


### PR DESCRIPTION
<img width="384" alt="image" src="https://github.com/aesoper101/vue3-colorpicker/assets/31615692/addf139a-5db3-4b68-8026-a7735265a658">

When we want to modify transparency, because we need to input a decimal point, 300 milliseconds is not enough. After testing, it takes 800 milliseconds
