### PR TITLE
fix(dev): release instance resource

### DIFF
--- a/packages/ColorPicker.vue
+++ b/packages/ColorPicker.vue
@@ -59,7 +59,7 @@
     ref,
     useSlots,
   } from "vue";
-  import { onClickOutside, tryOnMounted, whenever, useDebounceFn } from "@vueuse/core";
+  import { onClickOutside, tryOnMounted, whenever, useDebounceFn, tryOnUnmounted } from "@vueuse/core";
   import tinycolor, { ColorInputWithoutInstance } from "tinycolor2";
   import { ColorStop, GradientNode, parse, stringify } from "gradient-parser";
   import { createPopper, Instance } from "@popperjs/core";
@@ -398,6 +398,14 @@
           initProper();
         }
       });
+
+      tryOnUnmounted(() => {
+        // 释放instance资源
+        if (popperInstance) {
+          popperInstance?.destory();
+          popperInstance = null;
+        }
+      })
 
       whenever(
         () => props.gradientColor,


### PR DESCRIPTION
![8YtKfgc5eD](https://github.com/aesoper101/vue3-colorpicker/assets/3837008/a07c52b1-4d69-4bef-8966-21df06a0515e)
看到组件内部在组件销毁的时候未销毁popper 里面的instance实例，导致操作内存一致增加，会导致内存泄露
需要在组件销毁的时候同步销毁instance实例
测试结果：一个组件释放了700KB的内存资源
我们内部做了个patch包临时处理了，希望作者这边同步处理下
![img_v3_02au_7956f497-0f45-4002-94bb-242bb139d37g](https://github.com/aesoper101/vue3-colorpicker/assets/3837008/3ca5b828-3dc2-4d05-9608-674a45ade9d2)
![img_v3_02au_8b18a1fa-d842-4cbf-b0b6-98d8683783eg](https://github.com/aesoper101/vue3-colorpicker/assets/3837008/b94a8095-df8e-46d8-aa61-44a39dbd64c1)
![img_v3_02au_7d4df9e3-0b52-4574-86ee-5abdfbee887g](https://github.com/aesoper101/vue3-colorpicker/assets/3837008/3515b7ff-2bfb-4c6f-9d9c-65df1829a10d)

