### PR TITLE
fix: maps mouse events to document for improved UX

### DIFF
--- a/packages/common/Board.vue
+++ b/packages/common/Board.vue
@@ -4,8 +4,6 @@
     :class="['vc-saturation', { 'vc-saturation__chrome': round, 'vc-saturation__hidden': hide }]"
     :style="{ backgroundColor: state.hueColor }"
     @mousedown="onClickBoard"
-    @mousemove="onDrag"
-    @mouseup="onDragEnd"
   >
     <div class="vc-saturation__white"></div>
     <div class="vc-saturation__black"></div>
@@ -16,7 +14,16 @@
 </template>
 
 <script lang="ts">
-  import { computed, defineComponent, getCurrentInstance, nextTick, reactive, ref } from "vue";
+  import {
+    computed,
+    defineComponent,
+    getCurrentInstance,
+    nextTick,
+    reactive,
+    ref,
+    onMounted,
+    onBeforeUnmount,
+  } from "vue";
   import propTypes from "vue-types";
   import { clamp, Color } from "../utils/color";
   import { tryOnMounted, whenever } from "@vueuse/core";
@@ -50,7 +57,6 @@
       const cursorLeft = ref(0);
 
       const cursorElement = ref<HTMLElement | null>();
-      // const boardElement = ref<HTMLElement | null>();
 
       const getCursorStyle = computed(() => {
         return {
@@ -71,6 +77,8 @@
       const onClickBoard = (event: MouseEvent) => {
         mousedown = true;
         handleDrag(event as MouseEvent);
+        document.addEventListener("mousemove", onDrag);
+        document.addEventListener("mouseup", onDragEnd);
       };
 
       const onDrag = (event: MouseEvent) => {
@@ -81,6 +89,8 @@
 
       const onDragEnd = () => {
         mousedown = false;
+        document.removeEventListener("mousemove", onDrag);
+        document.removeEventListener("mouseup", onDragEnd);
       };
 
       const handleDrag = (event: MouseEvent) => {
@@ -127,6 +137,15 @@
         },
         { deep: true }
       );
+
+      onMounted(() => {
+        document.addEventListener("mouseup", onDragEnd);
+      });
+
+      onBeforeUnmount(() => {
+        document.removeEventListener("mouseup", onDragEnd);
+        document.removeEventListener("mousemove", onDrag);
+      });
 
       return { state, cursorElement, getCursorStyle, onClickBoard, onDrag, onDragEnd };
     },


### PR DESCRIPTION
# Problem
The mousemove and mouseup events were previously bound directly to the board element div. This caused difficulties for users trying to select colors at the extreme edges of the color picker, such as full black or full white. Users had to position their mouse precisely at the edges, which was often impossible, resulting in inaccurate color selection (e.g., a greyish color instead of full black or white).

# Solution
The mousemove and mouseup events have been remapped to the document object. This change ensures that the color selection can be accurately tracked even when the mouse moves outside the boundaries of the color picker element. Users can now easily select colors at the extreme edges without needing to precisely position their mouse.

# Video

✅ Improved UX (note how my cursor is leaving the board element while holding the left mouse button and still picking the proper color):
<video src="https://github.com/user-attachments/assets/0e472023-1279-4d86-abda-d6684ac47820" />

❌ Previous state:
<video src="https://github.com/user-attachments/assets/39357dee-e20a-4fb7-ac1c-3db051a104ed" />